### PR TITLE
Changed Title of Ghost Emoji to Ghost

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You should switch on the `emoji` argument in your implementation and return back
 🐈 - "Cat"  
 🐢 - "Turtle"  
 🍕 - "Pizza"  
-👻 - "Unknown"  
+👻 - "Ghost"  
 
 For the default case, we should return back the `String` "Unknown".
 


### PR DESCRIPTION
Readme had the Ghost Emoji as "Unknown" but "Unknown" is for the default case. Also the test was looking for "Ghost"